### PR TITLE
Allow S3 bucket region to be specified or detected.

### DIFF
--- a/target_redshift/sinks.py
+++ b/target_redshift/sinks.py
@@ -32,13 +32,18 @@ class RedshiftSink(SQLSink):
     """Redshift target sink class."""
 
     connector_class = RedshiftConnector
-    s3_client = boto3.client("s3", region_name="eu-west-1")
     MAX_SIZE_DEFAULT = 50000
 
     def __init__(self, *args, **kwargs):
         """Initialize SQL Sink. See super class for more details."""
         super().__init__(*args, **kwargs)
         self.temp_table_name = self.generate_temp_table_name()
+
+        region = self.config.get("s3_region")
+        if region is None:
+            self.s3_client = boto3.client("s3")
+        else:
+            self.s3_client = boto3.client("s3", region_name=region)
 
     @property
     def schema_name(self) -> str | None:

--- a/target_redshift/target.py
+++ b/target_redshift/target.py
@@ -71,6 +71,8 @@ class TargetRedshift(SQLTarget):
             "`activate_version` configuration to False."
         )
 
+        assert self.config.get("s3_bucket") is not None
+
     name = "target-redshift"
 
     config_jsonschema = th.PropertiesList(
@@ -151,6 +153,14 @@ class TargetRedshift(SQLTarget):
             th.StringType,
             required=True,
             description="S3 bucket to save staging files before using COPY command",
+        ),
+        th.Property(
+            "s3_region",
+            th.StringType,
+            description=(
+                "AWS region for S3 bucket. If not specified, region will be detected by boto config resolution."
+                + "See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html"
+            ),
         ),
         th.Property(
             "s3_key_prefix",


### PR DESCRIPTION
Fixes #102 

Adds new config setting `s3_region`. 
 - If specified, this region is given to the boto s3 client.
 - If not specified, no region is sent to the boto s3 client, and it'll use normal dependency resolution, e.g. the `AWS_REGION` environment variable
