### PR TITLE
Use config titles (new SDK feature)

### DIFF
--- a/target_redshift/target.py
+++ b/target_redshift/target.py
@@ -76,6 +76,7 @@ class TargetRedshift(SQLTarget):
                 "If true, use temporary credentials "
                 "(https://docs.aws.amazon.com/redshift/latest/mgmt/generating-iam-credentials-cli-api.html)."
             ),
+            title="Enable IAM Authentication",
         ),
         th.Property(
             "cluster_identifier",
@@ -107,6 +108,7 @@ class TargetRedshift(SQLTarget):
             description=(
                 "Database name. Note if sqlalchemy_url is set this will be ignored."
             ),
+            title="Database Name",
         ),
         th.Property(
             "aws_redshift_copy_role_arn",
@@ -114,6 +116,7 @@ class TargetRedshift(SQLTarget):
             secret=True,  # Flag config as protected.
             required=True,
             description="Redshift copy role arn to use for the COPY command from s3",
+            title="AWS Redshift Copy Role ARN",
         ),
         th.Property(
             "s3_bucket",


### PR DESCRIPTION
These were added in [v0.42.0](https://github.com/meltano/sdk/releases/tag/v0.42.0) from https://github.com/meltano/sdk/issues/2712.

They are used in the automation from target > Hub > `meltano lock` > `meltano config ... set --interactive`, so users see a nicely rendered field title in all places.

Let me know what you think!