### PR TITLE
add config option to grant select permissions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ ipykernel = "^6.29.5"
 [tool.ruff]
 src = ["target_redshift"]
 target-version = "py37"
+line-length = 120
 
 [tool.ruff.lint]
 ignore = [

--- a/target_redshift/connector.py
+++ b/target_redshift/connector.py
@@ -46,6 +46,21 @@ class RedshiftConnector(SQLConnector):
         if not schema_exists:
             self.create_schema(schema_name, cursor=cursor)
 
+    def grant_privileges(self, schema_name: str, cursor: Cursor) -> None:
+        """Grant privileges to the target schema.
+
+        Args:
+            schema_name: The target schema name.
+            cursor: The database cursor.
+        """
+        for grantee in self.config.get("grants", []):
+            cursor.execute(f"grant usage on schema {schema_name} to {grantee};")
+            cursor.execute(f"grant select on all tables in schema {schema_name} to {grantee};")
+            cursor.execute(
+                f"alter default privileges for user {self.config['user']} "
+                f"in schema {schema_name} grant select on tables to {grantee};"
+            )
+
     def create_schema(self, schema_name: str, cursor: Cursor) -> None:
         """Create target schema.
 

--- a/target_redshift/connector.py
+++ b/target_redshift/connector.py
@@ -287,7 +287,7 @@ class RedshiftConnector(SQLConnector):
                     property_name,
                     self.to_sql_type(property_jsonschema),
                     primary_key=is_primary_key,
-                    autoincrement=False,  # See: https://github.com/MeltanoLabs/target-postgres/issues/193 # noqa: E501
+                    autoincrement=False,  # See: https://github.com/MeltanoLabs/target-postgres/issues/193
                 )
             )
         if as_temp_table:

--- a/target_redshift/sinks.py
+++ b/target_redshift/sinks.py
@@ -88,6 +88,7 @@ class RedshiftSink(SQLSink):
                 cursor=cursor,
                 as_temp_table=False,
             )
+            self.connector.grant_privileges(self.schema_name, cursor=cursor)
 
     def generate_temp_table_name(self) -> str:
         """Uuid temp table name."""

--- a/target_redshift/target.py
+++ b/target_redshift/target.py
@@ -183,7 +183,7 @@ class TargetRedshift(SQLTarget):
             description=(
                 "Note that this must be enabled for activate_version to work!"
                 "This adds _sdc_extracted_at, _sdc_batched_at, and more to every "
-                "table. See https://sdk.meltano.com/en/latest/implementation/record_metadata.html "  # noqa: E501
+                "table. See https://sdk.meltano.com/en/latest/implementation/record_metadata.html"
                 "for more information."
             ),
         ),

--- a/target_redshift/target.py
+++ b/target_redshift/target.py
@@ -208,6 +208,11 @@ class TargetRedshift(SQLTarget):
                 " require, verify-ca, or verify-full."
             ),
         ),
+        th.Property(
+            "grants",
+            th.ArrayType(th.StringType),
+            description="List of users/roles/groups that will have select permissions on the tables",
+        )
     ).to_dict()
 
     default_sink_class = RedshiftSink


### PR DESCRIPTION
you can now use the `grants` config option to set users/groups/roles that will have select permissions on the schema and all tables in the schema created by the target.