### PR TITLE
Conform schema to redshift naming conventions

### DIFF
--- a/target_redshift/connector.py
+++ b/target_redshift/connector.py
@@ -201,9 +201,7 @@ class RedshiftConnector(SQLConnector):
         else:
             new_table = Table(table_name, meta, *columns)
 
-        create_table_ddl = str(
-            CreateTable(new_table).compile(dialect=self._engine.dialect)
-        )
+        create_table_ddl = str(CreateTable(new_table).compile(dialect=self._engine.dialect))
         cursor.execute(create_table_ddl)
         return new_table
 
@@ -276,10 +274,7 @@ class RedshiftConnector(SQLConnector):
         try:
             properties: dict = schema["properties"]
         except KeyError as e:
-            msg = (
-                f"Schema for table_name: '{table_name}'"
-                f"does not define properties: {schema}"
-            )
+            msg = f"Schema for table_name: '{table_name}'" f"does not define properties: {schema}"
             raise RuntimeError(msg) from e
 
         for property_name, property_jsonschema in properties.items():
@@ -297,9 +292,7 @@ class RedshiftConnector(SQLConnector):
         else:
             new_table = Table(table_name, meta, *columns)
 
-        create_table_ddl = str(
-            CreateTable(new_table).compile(dialect=self._engine.dialect)
-        )
+        create_table_ddl = str(CreateTable(new_table).compile(dialect=self._engine.dialect))
         cursor.execute(create_table_ddl)
         return new_table
 
@@ -320,10 +313,7 @@ class RedshiftConnector(SQLConnector):
             cursor: a database cursor.
             column_object: a SQLAlchemy column. optional.
         """
-        column_name = column_name.lower().replace(" ", "_")
-        column_exists = column_object is not None or self.column_exists(
-            full_table_name, column_name
-        )
+        column_exists = column_object is not None or self.column_exists(full_table_name, column_name)
 
         if not column_exists:
             self._create_empty_column(
@@ -397,10 +387,7 @@ class RedshiftConnector(SQLConnector):
         column = Column(column_name, column_type)
 
         return DDL(
-            (
-                'ALTER TABLE "%(schema_name)s"."%(table_name)s"'
-                "ADD COLUMN %(column_name)s %(column_type)s"
-            ),
+            ('ALTER TABLE "%(schema_name)s"."%(table_name)s"' "ADD COLUMN %(column_name)s %(column_type)s"),
             {
                 "schema_name": schema_name,
                 "table_name": table_name,
@@ -495,10 +482,7 @@ class RedshiftConnector(SQLConnector):
         """
         column = Column(column_name, column_type)
         return DDL(
-            (
-                'ALTER TABLE "%(schema_name)s"."%(table_name)s"'
-                "ALTER COLUMN %(column_name)s %(column_type)s"
-            ),
+            ('ALTER TABLE "%(schema_name)s"."%(table_name)s"' "ALTER COLUMN %(column_name)s %(column_type)s"),
             {
                 "schema_name": schema_name,
                 "table_name": table_name,

--- a/target_redshift/sinks.py
+++ b/target_redshift/sinks.py
@@ -253,13 +253,13 @@ class RedshiftSink(SQLSink):
             raise ValueError(msg)
         object_keys = [
             key
-            for key, value in self.schema["properties"].items()
+            for key, value in self.conformed_schema["properties"].items()
             if "object" in value["type"] or "array" in value["type"]
         ]
         return [
             {
                 key: (json.dumps(value).replace("None", "") if key in object_keys else value)
-                for key, value in record.items()
+                for key, value in self.conform_record(record).items()
             }
             for record in records
         ]


### PR DESCRIPTION
Use `self.conform_schema(self.schema)` in place of `self.schema` to use SQL snake-case property names and avoid duplicate columns on rerun

Use of `conform_schema` in Meltano SDK's SQLSink: https://github.com/meltano/sdk/blob/da17941f75f0703e378fa591ce6a48ac44516668/singer_sdk/sinks/sql.py#L240

There's some linting in here - all my changes involve `conformed_schema` and `conform_record`

Closes #207 

P.S. the linter is failing due to ruff version differences which I added on the other PR. i can gladly add that here or break it off into another if that makes sense